### PR TITLE
Cypress tests patch

### DIFF
--- a/tests/cypress/e2e/basics.cy.ts
+++ b/tests/cypress/e2e/basics.cy.ts
@@ -258,7 +258,10 @@ beforeEach(() => {
                 scssVars = (win as any)[WINDOW_STRYPE_SCSSVARS_PROPNAME];
                 strypeElIds = (win as any)[WINDOW_STRYPE_HTMLIDS_PROPNAME];
             });
-        }        
+        }      
+        
+        // Wait for code initialisation
+        cy.wait(2000);
     });
 });
 

--- a/tests/cypress/e2e/graphics.cy.ts
+++ b/tests/cypress/e2e/graphics.cy.ts
@@ -12,7 +12,10 @@ beforeEach(() => {
     cy.visit("/",  {onBeforeLoad: (win) => {
         win.localStorage.clear();
         win.sessionStorage.clear();
-    }});
+    }}).then(() => {
+        // Wait for code initialisation
+        cy.wait(2000);
+    });
 });
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/tests/cypress/e2e/media-literals.cy.ts
+++ b/tests/cypress/e2e/media-literals.cy.ts
@@ -18,7 +18,10 @@ beforeEach(() => {
     cy.visit("/",  {onBeforeLoad: (win) => {
         win.localStorage.clear();
         win.sessionStorage.clear();
-    }});
+    }}).then(() => {
+        // Wait for code initialisation
+        cy.wait(2000);
+    });
 });
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/tests/cypress/e2e/param-prompts.cy.ts
+++ b/tests/cypress/e2e/param-prompts.cy.ts
@@ -39,6 +39,9 @@ beforeEach(() => {
                 strypeElIds = (win as any)[WINDOW_STRYPE_HTMLIDS_PROPNAME];
             });
         }
+
+        // Wait for code initialisation
+        cy.wait(2000);
     });
 });
 

--- a/tests/cypress/e2e/structured-expressions-brackets.cy.ts
+++ b/tests/cypress/e2e/structured-expressions-brackets.cy.ts
@@ -23,6 +23,9 @@ beforeEach(() => {
         // The Strype IDs and CSS class names aren't directly used in the test
         // but they are used in the support file, so we make them available.
         cy.initialiseSupportStrypeGlobals();
+
+        // Wait for code initialisation
+        cy.wait(2000);
     });
 });
 

--- a/tests/cypress/e2e/structured-expressions-selection.cy.ts
+++ b/tests/cypress/e2e/structured-expressions-selection.cy.ts
@@ -13,6 +13,9 @@ beforeEach(() => {
         // The Strype IDs and CSS class names aren't directly used in the test
         // but they are used in the support file, so we make them available.
         cy.initialiseSupportStrypeGlobals();
+
+        // Wait for code initialisation
+        cy.wait(2000);
     });
 });
 

--- a/tests/cypress/e2e/structured-expressions-terms.cy.ts
+++ b/tests/cypress/e2e/structured-expressions-terms.cy.ts
@@ -23,6 +23,9 @@ beforeEach(() => {
         // The Strype IDs and CSS class names aren't directly used in the test
         // but they are used in the support file, so we make them available.
         cy.initialiseSupportStrypeGlobals();
+
+        // Wait for code initialisation
+        cy.wait(2000);
     });
 });
 

--- a/tests/cypress/e2e/structured-expressions.cy.ts
+++ b/tests/cypress/e2e/structured-expressions.cy.ts
@@ -23,6 +23,9 @@ beforeEach(() => {
         // The Strype IDs and CSS class names aren't directly used in the test
         // but they are used in the support file, so we make them available.
         cy.initialiseSupportStrypeGlobals();
+        
+        // Wait for code initialisation
+        cy.wait(2000);
     });
 });
 

--- a/tests/cypress/e2e/translation.cy.ts
+++ b/tests/cypress/e2e/translation.cy.ts
@@ -36,6 +36,8 @@ beforeEach(() => {
                 strypeElIds = (win as any)[WINDOW_STRYPE_HTMLIDS_PROPNAME];
             });
         }
+        // Wait for code initialisation
+        cy.wait(2000);
     });
 });
 


### PR DESCRIPTION
Some tests were failing before, and the way to sort them out was adding a small wait timer in beforeEach to let the code initialise.
However, I had not added this in all the Cypress tests and it seems that the problem can randomly happen in any other tests.

So I would like to add the timer once for all in all the tests so now they shouldn't fail (at least not because of the code not being ready).